### PR TITLE
Add artifacts option to keep entire test folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ The only required *inputs* are a string of `notebook-files` to test.
 | `notebook-vscode-ext` | VS Code Notebook extension to install | | `SAPSE.vscode-cds` |
 | `timeout` | Mocha timeout for VS Code tests | | `120000` |
 | `artifacts-on-success` | Upload artifacts on success | | `false` |
+| `artifacts-kind` | Copy folder to be uploaded as artifacts | | `file` | 
 
 ## Example usage
 

--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,10 @@ inputs:
     description: "Whether to create artifacts on success"
     required: false
     default: false
+  artifacts-kind:
+    description: "Kind of artifacts to be created"
+    required: false
+    default: 'file'
 
 runs:
   using: "composite"
@@ -39,6 +43,7 @@ runs:
         echo "TIMEOUT=${{ inputs.timeout }}" >> $GITHUB_ENV
         echo "NOTEBOOK_VSCODE_EXT=${{ inputs.notebook-vscode-ext }}" >> $GITHUB_ENV
         echo "NOTEBOOK_FILE_EXT=${{ inputs.notebook-file-ext }}" >> $GITHUB_ENV
+        echo "ARTIFACTS_KIND=${{ inputs.artifacts-kind }}" >> $GITHUB_ENV
 
         # Without self-hosted container, use ${{ github.action_path }} instead
         cp -r ${GITHUB_ACTION_PATH}/vscode-notebook-runner .

--- a/vscode-notebook-runner/.gitignore
+++ b/vscode-notebook-runner/.gitignore
@@ -1,6 +1,6 @@
 .vscode-test/
 
 node_modules/
-test/data
+test/data/
 
 *.vsix

--- a/vscode-notebook-runner/.vscode/launch.json
+++ b/vscode-notebook-runner/.vscode/launch.json
@@ -15,7 +15,8 @@
 			"request": "launch",
 			"env": {
 				"NOTEBOOK_FILE_EXT": "capnb",
-				"TIMEOUT": "100000"
+				"TIMEOUT": "100000",
+				"ARTIFACTS_KIND": "folder"
 			},
 			"args": [
 				"--extensionDevelopmentPath=${workspaceFolder}",

--- a/vscode-notebook-runner/test/suite/notebook.test.js
+++ b/vscode-notebook-runner/test/suite/notebook.test.js
@@ -10,7 +10,8 @@ const { describe, it } = require('mocha');
 const sleep = async (time) => new Promise(r => setTimeout(r, time));
 
 const inputs = {
-    NOTEBOOK_FILE_EXT: process.env.NOTEBOOK_FILE_EXT
+    NOTEBOOK_FILE_EXT: process.env.NOTEBOOK_FILE_EXT,
+    ARTIFACTS_KIND: process.env.ARTIFACTS_KIND
 }
 
 describe('Notebook Integration Testing', () => {
@@ -71,7 +72,13 @@ describe('Notebook Integration Testing', () => {
         await vscode.workspace.saveAll();
 
         await fsp.mkdir(path.join(__dirname, outDir), { recursive: true }).catch((err) => console.log(err));
-        await vscode.workspace.fs.copy(nbUri, vscode.Uri.file(path.join(__dirname, outDir, nb)), { overwrite: true });
+        if (inputs.ARTIFACTS_KIND === 'folder') {
+            const srcnbPathUri = vscode.Uri.file(tempFolder);
+            const destnbPathUri = vscode.Uri.file(path.join(__dirname, outDir, 'test_' + nb.replace(`.${inputs.NOTEBOOK_FILE_EXT}`, '')));
+            await vscode.workspace.fs.copy(srcnbPathUri, destnbPathUri, { overwrite: true });
+        } else if (inputs.ARTIFACTS_KIND === 'file') {
+            await vscode.workspace.fs.copy(nbUri, vscode.Uri.file(path.join(__dirname, outDir, nb)), { overwrite: true });
+        }
 
         for (let i=0; i<notebook.cellCount; i++) {
             const kind = notebook.cellAt(i).kind;


### PR DESCRIPTION
- Some Notebooks may create files and folders that one might want to inspect in addition to the Notebooks themselves.
- For these cases, offer the input option `artifacts-kind: 'file' | 'folder'`, which on kind `folder` will copy and upload the entire test folder in which the Notebook ran and by default (kind `file`) will copy and upload only the Notebook as artifacts.