### PR TITLE
Add VS Code version option

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,9 @@ The only required *inputs* are a string of `notebook-files` to test.
 | Name | Description | Required | Default |
 | --- | --- | :---: | ---- |
 | `notebook-files` | Notebooks to be tested, separated by spaces | ✓ ||
-| `notebook-file-ext` | Notebook file extension | | `.capnb` |
+| `notebook-file-ext` | Notebook file extension | | `capnb` |
 | `notebook-vscode-ext` | VS Code Notebook extension to install | | `SAPSE.vscode-cds` |
+| `vscode-version` | VS Code version to use | | `stable` |
 | `timeout` | Mocha timeout for VS Code tests | | `120000` |
 | `artifacts-on-success` | Upload artifacts on success | | `false` |
 | `artifacts-kind` | Copy folder to be uploaded as artifacts | | `file` | 

--- a/action.yml
+++ b/action.yml
@@ -12,10 +12,14 @@ inputs:
     description: "Notebook file extension"
     required: false
     default: 'capnb'
-  notebook-vscode-ext:
+  notebook-vscode--ext:
     description: "Notebook VS Code extension"
     required: false
     default: 'SAPSE.vscode-cds'
+  vscode-version:
+    description: "VS Code version"
+    required: false
+    default: 'stable'
   timeout:
     description: "Mocha timeout for VS Code tests"
     require: false

--- a/vscode-notebook-runner/.vscode/extensions.json
+++ b/vscode-notebook-runner/.vscode/extensions.json
@@ -1,7 +1,0 @@
-{
-	// See https://go.microsoft.com/fwlink/?LinkId=733558
-	// for the documentation about the extensions.json format
-	"recommendations": [
-		"dbaeumer.vscode-eslint"
-	]
-}

--- a/vscode-notebook-runner/test/runTest.js
+++ b/vscode-notebook-runner/test/runTest.js
@@ -4,7 +4,8 @@ const path = require('path');
 const { downloadAndUnzipVSCode, resolveCliArgsFromVSCodeExecutablePath, runTests } = require('@vscode/test-electron');
 
 const inputs = {
-  NOTEBOOK_VSCODE_EXT: process.env.NOTEBOOK_VSCODE_EXT
+  NOTEBOOK_VSCODE_EXT: process.env.NOTEBOOK_VSCODE_EXT,
+  VSCODE_VERSION: process.env.VSCODE_VERSION
 }
 
 async function main() {
@@ -14,13 +15,20 @@ async function main() {
     const vscodeExecutablePath = await downloadAndUnzipVSCode();
     const [cliPath, ...args] = resolveCliArgsFromVSCodeExecutablePath(vscodeExecutablePath);
 
+    for (let vscode_ext of inputs.NOTEBOOK_VSCODE_EXT.trim().split(/\s+/g)) {
+      args.push('--install-extension', vscode_ext);
+    }
+    
     cp.spawnSync(
       cliPath,
-      [...args, '--install-extension', inputs.NOTEBOOK_VSCODE_EXT],
+      [...args],
       { encoding: 'utf-8', stdio: 'inherit' }
     );
 
-    await runTests({ vscodeExecutablePath, extensionDevelopmentPath, extensionTestsPath });
+    await runTests({
+      version: inputs.VSCODE_VERSION,
+      vscodeExecutablePath, 
+      extensionDevelopmentPath, extensionTestsPath });
   } catch (err) {
     console.error('Failed to run tests:');
 	console.log(err);


### PR DESCRIPTION
- Add option `vscode-version` to set the version of VS Code test with with
- Enable option `notebook-vscode-ext` to install more than one VS Code extension